### PR TITLE
INFRA-598 - Support TLS brokers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Options:
   -b, --broker-url TEXT      URL to the Celery broker.  [env var:
                              CELERY_EXPORTER_BROKER_URL; default:
                              redis://redis:6379/0]
-  --broker-use-ssl           Enable TLS/SSL on the Celery broker
+  -s, --broker-use-ssl       Enable TLS/SSL on the Celery broker
   -l, --listen-address TEXT  Address the HTTPD should listen on.  [env var:
                              CELERY_EXPORTER_LISTEN_ADDRESS; default:
                              0.0.0.0:9540]

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Options:
   -b, --broker-url TEXT      URL to the Celery broker.  [env var:
                              CELERY_EXPORTER_BROKER_URL; default:
                              redis://redis:6379/0]
+  --broker-use-ssl           Enable TLS/SSL on the Celery broker
   -l, --listen-address TEXT  Address the HTTPD should listen on.  [env var:
                              CELERY_EXPORTER_LISTEN_ADDRESS; default:
                              0.0.0.0:9540]

--- a/celery_exporter/__main__.py
+++ b/celery_exporter/__main__.py
@@ -25,8 +25,10 @@ LOG_FORMAT = "[%(asctime)s] %(name)s:%(levelname)s: %(message)s"
 )
 @click.option(
     "--broker-use-ssl",
+    "-s",
     is_flag=True,
-    allow_from_autoenv=False,
+    show_default=True,
+    show_envvar=True,
     default=False,
     help="Celery broker use TLS/SSL.",
 )

--- a/celery_exporter/__main__.py
+++ b/celery_exporter/__main__.py
@@ -24,6 +24,13 @@ LOG_FORMAT = "[%(asctime)s] %(name)s:%(levelname)s: %(message)s"
     help="URL to the Celery broker.",
 )
 @click.option(
+    "--broker-use-ssl",
+    is_flag=True,
+    allow_from_autoenv=False,
+    default=False,
+    help="Celery broker use TLS/SSL.",
+)
+@click.option(
     "--listen-address",
     "-l",
     type=str,
@@ -71,6 +78,7 @@ LOG_FORMAT = "[%(asctime)s] %(name)s:%(levelname)s: %(message)s"
 @click.version_option(version=".".join([str(x) for x in __VERSION__]))
 def main(
     broker_url,
+    broker_use_ssl,
     listen_address,
     max_tasks,
     namespace,
@@ -103,6 +111,7 @@ def main(
 
     celery_exporter = CeleryExporter(
         broker_url,
+        broker_use_ssl,
         listen_address,
         max_tasks,
         namespace,

--- a/celery_exporter/core.py
+++ b/celery_exporter/core.py
@@ -15,6 +15,7 @@ class CeleryExporter:
     def __init__(
         self,
         broker_url,
+        broker_use_ssl,
         listen_address,
         max_tasks=10000,
         namespace="celery",
@@ -26,7 +27,7 @@ class CeleryExporter:
         self._namespace = namespace
         self._enable_events = enable_events
 
-        self._app = celery.Celery(broker=broker_url)
+        self._app = celery.Celery(broker=broker_url, broker_use_ssl=broker_use_ssl)
         self._app.conf.broker_transport_options = transport_options or {}
 
     def start(self):


### PR DESCRIPTION
What does this do ?
* [INFRA-598 - RabbitMQ Prometheus Exporters](https://doctorondemand.atlassian.net/browse/INFRA-598)
* Pulls in upstream [OvalMoney/celery-exporter - Added broker-use-ssl flag #24](https://github.com/OvalMoney/celery-exporter/pull/24)
* Adds some enhancements - click ENV var binding