### PR TITLE
test python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 
 python:
-  - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "3.6"
   - "3.7"
   - "3.8"
+  - "3.9"
 
 env:
   - RUSTUP_HOME=~/rustup CARGO_HOME=~/cargo PATH=~/cargo/bin:$PATH

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38}-celery4, lint
+envlist = py{35,36,37,38,39}-celery4, lint
 skipsdist = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36,37,38,39}-celery4, lint
+envlist = py{36,37,38,39}-celery4, lint
 skipsdist = true
 
 [testenv]


### PR DESCRIPTION
add python3.9 to test matrix and drop python 3.5 since maturin builds wheel for 3.6,3.7,3.8,3.9


closes #46 