### PR TITLE
travis: avoid executing install block from test jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ jobs:
         - docker
       env: TWINE_USERNAME=$PYPI_USER
            TWINE_PASSWORD=$PYPI_PASSWORD
-      before_script:
+      install:
         - pip install twine
       script:
         - maturin sdist


### PR DESCRIPTION
reintroduces a fix from #44  which was lost during rebase