### PR TITLE
fix sdist & deploy release bdist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ jobs:
         - pip install twine maturin==0.8.3
       script:
         - maturin sdist
-        - docker run --rm -v $(pwd):/io konstin2/maturin build -o dist/
+        - docker run --rm -v $(pwd):/io konstin2/maturin build --release -o dist/
         - twine upload --skip-existing dist/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ jobs:
       env: TWINE_USERNAME=$PYPI_USER
            TWINE_PASSWORD=$PYPI_PASSWORD
       install:
-        - pip install twine
+        - pip install twine maturin==0.8.3
       script:
         - maturin sdist
         - docker run --rm -v $(pwd):/io konstin2/maturin build -o dist/

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,5 +29,5 @@ jobs:
         - pip install twine maturin==0.8.3
       script:
         - maturin sdist
-        - docker run --rm -v $(pwd):/io konstin2/maturin build --release -o dist/
+        - docker run --rm -v $(pwd):/io konstin2/maturin:v0.8.3 build --release -o dist/
         - twine upload --skip-existing dist/*


### PR DESCRIPTION
reverts [faedbe4](https://github.com/OvalMoney/celery-exporter/commit/faedbe4f33a16a086c51e130d28e6fcad56038f5) which breaks source distribution and add release flag to bdist_wheel